### PR TITLE
Make the OverlaySpotlight draw from edge to edge

### DIFF
--- a/TourCompose/src/main/java/com/tonyakitori/apps/tourcompose/TourCompose.kt
+++ b/TourCompose/src/main/java/com/tonyakitori/apps/tourcompose/TourCompose.kt
@@ -3,13 +3,10 @@ package com.tonyakitori.apps.tourcompose
 import android.util.Log
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -115,30 +112,14 @@ fun TourCompose(
         tail
     }
 
-    val finalComponentRect = run {
-        val safeDrawingPaddingValues = WindowInsets.safeDrawing.asPaddingValues()
-        val topPadding = with(LocalDensity.current) { safeDrawingPaddingValues.calculateTopPadding().toPx() }
-
-        if (topPadding > 0) {
-            Rect(
-                left = componentRectArea.left,
-                top = componentRectArea.top.minus(topPadding),
-                right = componentRectArea.right,
-                bottom = componentRectArea.bottom.minus(topPadding)
-            )
-        } else {
-            componentRectArea
-        }
-    }
-
     val bubblePositionModifier = with(density) {
         if (spotlightCenterY < screenHeight / 2) {
             Modifier.offset(
-                y = (finalComponentRect.bottom + BUBBLE_OFFSET_Y_BOTTOM.dp.toPx()).toDp()
+                y = (componentRectArea.bottom + BUBBLE_OFFSET_Y_BOTTOM.dp.toPx()).toDp()
             )
         } else {
             Modifier.offset(
-                y = (finalComponentRect.top - (contentSize.height + BUBBLE_OFFSET_Y_TOP.dp.toPx())).toDp()
+                y = (componentRectArea.top - (contentSize.height + BUBBLE_OFFSET_Y_TOP.dp.toPx())).toDp()
             )
         }
     }
@@ -146,6 +127,7 @@ fun TourCompose(
     Popup(
         properties = PopupProperties(
             focusable = true,
+            clippingEnabled = false,
         ),
         popupPositionProvider = object : PopupPositionProvider {
             override fun calculatePosition(
@@ -172,7 +154,7 @@ fun TourCompose(
         ) {
             OverlaySpotlight(
                 modifier = Modifier,
-                componentSelectedRect = finalComponentRect,
+                componentSelectedRect = componentRectArea,
                 isOverflow = isComponentOverflowing,
                 colors = tourComposeProperties.spotlightColors
             )


### PR DESCRIPTION
I added the clippingEnabled flag to the Popup so that the overlay can draw from edge to edge, which I think looks better.

PS. Great library!

| Before | After&nbsp;&nbsp;&nbsp; |
| -- | -- |
| <img width="1080" height="2400" alt="obraz" src="https://github.com/user-attachments/assets/fd228386-5c1c-4a6e-90bc-f7a4d869594e" /> | <img width="1080" height="2400" alt="obraz" src="https://github.com/user-attachments/assets/ebcba394-d4e2-460f-a0d2-c469135f8f89" /> |
